### PR TITLE
feat(67): 조회 권한이 없는 캘린더 접근 시 Alert Modal 띄우기

### DIFF
--- a/frontend/src/app/calendar/[id]/page.tsx
+++ b/frontend/src/app/calendar/[id]/page.tsx
@@ -12,11 +12,13 @@ import { useEffect, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { MusicRecord } from "@/types/musicRecord";
 import { AxiosError } from "axios";
-import { useGlobalAlert } from "@/components/GlobalAlert";
 import { fetchMusicRecords } from "@/lib/api/musicRecord";
 import { getSpotifyAccessToken } from "@/app/utils/getSpotifyAccessToken";
+import {useModal} from "@/hooks/useModal";
 
 export default function MusicDetailPage() {
+  const { showAlert, ModalComponent } = useModal();
+
   const [musicRecord, setMusicRecord] = useState<MusicRecord>();
   const [currentYear, setCurrentYear] = useState<number>(
     new Date().getFullYear()
@@ -27,7 +29,6 @@ export default function MusicDetailPage() {
   const [currentDay, setCurrentDay] = useState<number>(new Date().getDay());
   const [calendarPermission, setCalendarPermission] = useState<string | null>();
   const [isPremium, setIsPremium] = useState<boolean | null>(null);
-  const { setAlert } = useGlobalAlert();
 
   const params = useParams();
   const router = useRouter();
@@ -47,14 +48,15 @@ export default function MusicDetailPage() {
         setCalendarPermission(musicRecord.calendarPermission);
       } catch (error) {
         if (error instanceof AxiosError)
-          setAlert({
-            code: error.response!.status.toString(),
-            message: error.response!.data.msg,
+          await showAlert({
+            title: error.response!.data.msg,
+            description: "확인 버튼을 누르면 내 캘린더로 이동합니다.",
+            confirmText: "확인",
+            onConfirm: () => {
+              router.push("/calendar");
+            },
           });
 
-        setTimeout(() => {
-          router.push("/calendar");
-        }, 2000); // 2초 대기 후 이동
         return;
       }
     }
@@ -174,6 +176,7 @@ export default function MusicDetailPage() {
           ▶️ Spotify에서 플레이리스트 듣기
         </button>
       )}
+      {ModalComponent}
     </div>
   );
 }

--- a/frontend/src/app/calendar/[id]/page.tsx
+++ b/frontend/src/app/calendar/[id]/page.tsx
@@ -55,6 +55,7 @@ export default function MusicDetailPage() {
             onConfirm: () => {
               router.push("/calendar");
             },
+            canClose: false,
           });
 
         return;

--- a/frontend/src/components/AlertModal.tsx
+++ b/frontend/src/components/AlertModal.tsx
@@ -6,6 +6,7 @@ import {
   DialogTitle,
   DialogFooter,
 } from "@/components/ui/dialog";
+import {cn} from "@/lib/utils";
 
 interface AlertModalProps {
   open: boolean;
@@ -16,6 +17,7 @@ interface AlertModalProps {
   cancelText?: string;
   onClose: () => void;
   onConfirm?: () => void;
+  canClose?: boolean;
 }
 
 export default function AlertModal({
@@ -27,12 +29,17 @@ export default function AlertModal({
   cancelText = "취소",
   onClose,
   onConfirm,
+  canClose = true,
 }: AlertModalProps) {
   const isConfirm = type === "confirm";
 
   return (
     <Dialog open={open} onOpenChange={onClose}>
-      <DialogContent className="max-w-sm sm:max-w-md w-full p-6 rounded-xl bg-white shadow-xl z-50">
+      <DialogContent className={cn("max-w-sm sm:max-w-md w-full p-6 rounded-xl bg-white shadow-xl z-50",
+        !canClose && "[&>button[type=button]]:hidden")}
+        onEscapeKeyDown={!canClose ? (e) => e.preventDefault() : undefined}
+        onPointerDownOutside={!canClose ? (e) => e.preventDefault() : undefined}
+      >
         <DialogHeader className="bg-[#C8B6FF] -mx-6 -mt-6 px-6 py-4 rounded-t-xl">
           <DialogTitle className="text-lg font-bold">{title}</DialogTitle>
         </DialogHeader>

--- a/frontend/src/components/calendar/Calendar.tsx
+++ b/frontend/src/components/calendar/Calendar.tsx
@@ -132,6 +132,7 @@ const Calendar: React.FC = () => {
             onConfirm: () => {
               router.push("/calendar");
             },
+            canClose: false,
           });
       }
     }

--- a/frontend/src/components/calendar/Calendar.tsx
+++ b/frontend/src/components/calendar/Calendar.tsx
@@ -21,8 +21,11 @@ import { fetchFollowCount } from "@/lib/api/follow";
 import { fetchMonthlyData } from "@/lib/api/calendar";
 import "@/components/style/calendar.css";
 import LoadingSpinner from "@/components/LoadingSpinner";
+import { useModal } from "@/hooks/useModal";
 
 const Calendar: React.FC = () => {
+  const { showAlert, ModalComponent } = useModal();
+
   const [monthly, setMonthly] = useState<CalendarDate[]>([]);
   const [selectedYear, setSelectedYear] = useState<number>(
     new Date().getFullYear()
@@ -122,16 +125,14 @@ const Calendar: React.FC = () => {
       } catch (error) {
         // 예외 처리
         if (error instanceof AxiosError)
-          setAlert({
-            code: error.response!.status.toString(),
-            message: error.response!.data.msg,
+          await showAlert({
+            title: error.response!.data.msg,
+            description: "확인 버튼을 누르면 내 캘린더로 이동합니다.",
+            confirmText: "확인",
+            onConfirm: () => {
+              router.push("/calendar");
+            },
           });
-
-        setTimeout(() => {
-          router.push("/calendar");
-        }, 2000); // 2초 대기 후 이동
-
-        return;
       }
     }
 
@@ -315,6 +316,7 @@ const Calendar: React.FC = () => {
               showNonCurrentDates={false}
             />
           </div>
+          {ModalComponent}
         </div>
       )}
     </>

--- a/frontend/src/hooks/useModal.tsx
+++ b/frontend/src/hooks/useModal.tsx
@@ -8,6 +8,7 @@ type ModalOptions = {
   confirmText?: string;
   cancelText?: string;
   onConfirm?: () => void;
+  canClose?: boolean;
 };
 
 export const useModal = () => {
@@ -65,6 +66,7 @@ export const useModal = () => {
       cancelText={options.cancelText}
       onClose={handleClose}
       onConfirm={handleConfirm}
+      canClose={options.canClose}
     />
   );
 

--- a/frontend/src/hooks/useModal.tsx
+++ b/frontend/src/hooks/useModal.tsx
@@ -7,6 +7,7 @@ type ModalOptions = {
   description?: string;
   confirmText?: string;
   cancelText?: string;
+  onConfirm?: () => void;
 };
 
 export const useModal = () => {
@@ -40,6 +41,10 @@ export const useModal = () => {
   };
 
   const handleConfirm = () => {
+    if (options.onConfirm) {
+      options.onConfirm();
+    }
+
     if (onResolve) {
       if (options.type === "confirm") {
         (onResolve as (result: boolean) => void)(true);


### PR DESCRIPTION
## 🔎 작업 내용
- 조회 권한이 없는 먼슬리 캘린더 접근 시 Alert Modal 띄우기
- 조회 권한이 없는 캘린더 접근 시 Alert Modal 띄우기
- 유저가 Alert Modal을 닫을 수 없도록 처리
    - Alert Modal 바깥 영역 클릭 방지
    - ESC 키 누름 방지
    - Alert Modal 닫기 버튼 숨기기

  <br/>

## 이미지 첨부
<img width="960" alt="monthly-alert" src="https://github.com/user-attachments/assets/fd29de33-120b-480e-985d-e2c8c661c0da" />
<img width="960" alt="calendar-alert" src="https://github.com/user-attachments/assets/fb104a97-4330-4310-ab1e-6025442ad30e" />

<br/>

## ➕ 이슈 링크
- [NBE4-5-3-Team01 #67 ](https://github.com/prgrms-be-devcourse/NBE4-5-3-Team01/issues/67)

<br/>

<!-- closed #67 -->
